### PR TITLE
fix counted_by member lookup in nested non-anonymous structs

### DIFF
--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -5086,8 +5086,24 @@ void Parser::ParseStructUnionBody(SourceLocation RecordLoc,
           // parsing now for non-anonymous records; anonymous struct/union
           // fields are handled as part of the enclosing record instead.
           if (RD && !RD->isAnonymousStructOrUnion()) {
+            std::optional<ParseScope> RecordReentryScope;
+            if (!getLangOpts().CPlusPlus) {
+              RecordReentryScope.emplace(this,
+                                         Scope::ClassScope | Scope::DeclScope);
+              Actions.EnterDeclaratorContext(getCurScope(), RD);
+              for (Decl *D : RD->decls()) {
+                if (auto *ND = dyn_cast<NamedDecl>(D)) {
+                  if (ND->getDeclName())
+                    Actions.PushOnScopeChains(ND, getCurScope(),
+                                              /*AddToContext=*/false);
+                }
+              }
+            }
+
             Actions.ProcessLateParsedTypeAttributes(
                 RD, ParseLateParsedTypeAttributeCallback);
+            if (RecordReentryScope)
+              Actions.ExitDeclaratorContext(getCurScope());
           }
         } else {
           DiagnoseCountAttributedTypeInUnnamedAnon(DS, *this);


### PR DESCRIPTION
This is the fix for the first [failing test](https://github.com/llvm/llvm-project/blob/d8c3981787a77ec63454baab99e96d2e13e59c34/clang/test/Sema/attr-counted-by-late-parsed-struct-ptrs-anon.c#L60)